### PR TITLE
Make build for Windows working

### DIFF
--- a/abc-sys/build.rs
+++ b/abc-sys/build.rs
@@ -1063,6 +1063,7 @@ fn main() {
 
     cc.warnings(false)
         .define("ABC_USE_STDINT_H", "1")
+        .define("WIN32_NO_DLL", "")
         .flag_if_supported("-Wno-unused-function")
         .flag_if_supported("-Wno-write-strings")
         .flag_if_supported("-Wno-sign-compare")

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -53,6 +53,13 @@ impl RssStats {
     fn now() -> Self {
         #[cfg(not(miri))]
         {
+            #[cfg(target_os = "windows")]
+            {
+                Self {
+                    current: MemoryAmount(0),
+                    max: MemoryAmount(0),
+                }
+            }
             #[cfg(target_os = "macos")]
             {
                 // SAFETY: rusage is plain old data so all zeros is valid


### PR DESCRIPTION
Add new compile define parameter WIN32_NO_DLL, this does not affect any other OS.

Logger updated to with dummy default for Windows platform.