### PR TITLE
feat: add doc based on sphinx

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,60 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'imctk'
+copyright = '2024, YosysHQ'
+author = 'YosysHQ'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinxcontrib_rust", "myst_parser"]
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+    ".txt": "markdown", # Optional
+}
+myst_enable_extensions = {
+    "colon_fence",
+    "html_admonition",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "tasklist",
+}
+rust_crates = {
+    "ids": "../ids",
+    "imctk-derive": "../derive",
+    "imctk-transparent": "../transparent",
+    "table_seq": "../table_seq",
+    "imctk-aiger": "../aiger",
+    "imctk-logger": "../logger",
+    "imctk-util": "../util",
+    "imctk-ir": "../ir",
+    "imctk-abc-sys": "../abc-sys",
+    "imctk-abc": "../abc",
+    "imctk-eqy-engine": "../eqy-engine",
+    "imctk-inc_refine": "../inc_refine",
+    "imctk-extract": "../extract",
+    "imctk": "../imctk",
+    "imctk-lit": "../lit",
+}
+rust_doc_dir = "build/crates/"
+rust_rustdoc_fmt = "rst"
+
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,20 @@
+.. imctk documentation master file, created by
+   sphinx-quickstart on Sat Oct 26 14:55:19 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to imctk's documentation!
+=================================
+ 
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
add sphinx based doc, and use sphinxcontrib-rust as convertor. the mainline of it is not usable for imctk doc build, and I make some fix in https://gitlab.com/chenbott/sphinxcontrib-rust, I will make a merge request later(origin repo: https://gitlab.com/munir0b0t/sphinxcontrib-rust)